### PR TITLE
Add the "Guard" action to UAI packages

### DIFF
--- a/0-XNPCCore/Config/dialogs.xml
+++ b/0-XNPCCore/Config/dialogs.xml
@@ -12,6 +12,7 @@
         <response_entry id="ShowMe" />
         <response_entry id="StayHere" />
         <response_entry id="GuardHere" />
+        <response_entry id="GuardReturnHere" />
         <response_entry id="Wander" />
         <response_entry id="SetPatrol" />
         <response_entry id="SetCode" />
@@ -63,6 +64,12 @@
         <requirement type="Leader, SCore" requirementtype="Hide" />
         <requirement type="HasTask, SCore" requirementtype="Hide" value="Stay" />
         <action type="AddBuffSDX, SCore" value="Self" id="buffOrderGuardHere" />
+      </response>
+
+    <response id="GuardReturnHere" text="Guard and return to where I am standing" >
+        <requirement type="Leader, SCore" requirementtype="Hide" />
+        <requirement type="HasTask, SCore" requirementtype="Hide" value="Guard" />
+        <action type="AddBuffSDX, SCore" value="Self" id="buffOrderGuard" />
       </response>
 
     <!-- <response id="SetCode" text="Here is your Patrol Code" >
@@ -123,6 +130,7 @@
         <response_entry id="ShowMe" />
         <response_entry id="StayHere" />
         <response_entry id="GuardHere" />
+        <response_entry id="GuardReturnHere" />
         <response_entry id="Wander" />
         <response_entry id="SetPatrol" />
         <response_entry id="Patrol" />
@@ -198,6 +206,12 @@
         <requirement type="Leader, SCore" requirementtype="Hide" />
         <requirement type="HasTask, SCore" requirementtype="Hide" value="Stay" />
         <action type="AddBuffSDX, SCore" value="Self" id="buffOrderGuardHere" /> 
+      </response>
+    
+    <response id="GuardReturnHere" text="Guard and return here" >
+        <requirement type="Leader, SCore" requirementtype="Hide" />
+        <requirement type="HasTask, SCore" requirementtype="Hide" value="Guard" />
+        <action type="AddBuffSDX, SCore" value="Self" id="buffOrderGuard" /> 
       </response>
   
 	  <response id="Dismiss" text="Abandon" >

--- a/0-XNPCCore/Config/utilityai.xml
+++ b/0-XNPCCore/Config/utilityai.xml
@@ -41,6 +41,10 @@
                     <consideration class="EnemyNotNear, SCore" />
                     <consideration class="HasOrder, SCore" order="Stay"/>
                 </action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 				<action name="Flee" weight="6" entity_filter="IsEnemy">
 					<task class="FleeFromTarget" max_distance="30"/>
 					<consideration class="SelfHasCVar, SCore" cvar="$Timid" value="1"/>
@@ -59,6 +63,10 @@
                     <task class="IdleSDX, SCore" OnStartAddBuffs="RandomIdle" OnStopRemoveBuffs="RandomIdle" /> 
 						<consideration class="HasOrder, SCore" order="Stay"/>
 				</action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 				<action name="OnReload" weight="3" entity_filter="IsSelf" >
                     <task class="IdleSDX, SCore"  /> 
                     <consideration class="SelfHasBuff, SCore" buffs="buffReload2,buffReloadDelay,buffReload3"/> 
@@ -626,6 +634,10 @@
 					<consideration class="EnemyNotNear, SCore"/>
 					<consideration class="HasOrder, SCore" order="Stay"/>
 				</action>  
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 				<action name="Flee" weight="6">
 					<task class="FleeFromTarget" max_distance="30"/>
 					<consideration class="SelfHasCVar, SCore" cvar="Timid" value="1"/>
@@ -650,6 +662,10 @@
                     <consideration class="EnemyNotNear, SCore" />
                     <consideration class="HasOrder, SCore" order="Stay"/>
                 </action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
             </ai_package>
 			
 			<ai_package name="NPCAnimalHiredCompanion" entity_filter="IsLeader" >
@@ -718,6 +734,10 @@
                     <consideration class="EnemyNotNear, SCore" />
                     <consideration class="HasOrder, SCore" order="Stay"/>
                 </action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 				<action name="HealSelf" weight="6" entity_filter="IsSelf">
 					<task class="HealSDX, SCore" OnStartAddBuffs="IsHealing" OnStopAddBuffs="buffProcessConsumables"/>
 					<consideration class="SelfHealthSDX, SCore" min="0.01" max="0.60"/>
@@ -783,6 +803,10 @@
                     <consideration class="EnemyNotNear, SCore" />
                     <consideration class="HasOrder, SCore" order="Stay"/>
                 </action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 			</ai_package>
 
 			<ai_package name="NPCModBasicRanged" >
@@ -810,6 +834,10 @@
                     <consideration class="EnemyNotNear, SCore" />
                     <consideration class="HasOrder, SCore" order="Stay"/>
                 </action> 
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 			</ai_package>
 
 			<ai_package name="NPCModBasicMeleeNoChat" >
@@ -817,6 +845,10 @@
 					<task class="WanderSDX, SCore"/>
                     <consideration class="NotHasOrder, SCore" order="Stay"/>
 					<task class="IdleSDX, SCore" OnStartAddBuffs="RandomWanderIdle" OnStopRemoveBuffs="RandomWanderIdle" timeout="50" />
+				</action>
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
 				</action>
 				<action name="OnReload" weight="3" entity_filter="IsSelf" >
                     <task class="IdleSDX, SCore"  /> 
@@ -829,6 +861,10 @@
 					<task class="WanderSDX, SCore"/>
                     <consideration class="NotHasOrder, SCore" order="Stay"/>
 					<task class="IdleSDX, SCore" OnStartAddBuffs="RandomWanderIdle" OnStopRemoveBuffs="RandomWanderIdle" timeout="50" /><!-- fires an Idle buff on start, removes same on exit  -->
+				</action>
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
 				</action>
 				<action name="OnReload" weight="3" entity_filter="IsSelf" >
                     <task class="IdleSDX, SCore"  /> 


### PR DESCRIPTION
This adds a "Guard" tasks to the basic packages. It has an equal weight to "Stay" and does mostly the same thing, except that it considers the "Guard" order rather than the "Stay" order.

This means any actions with a higher priority will still be performed (even the ones that usually do not because of the "Stay" order). That's intentional, it means the entities can go attack something, then return to their guard position after the enemy has been killed.

The tasks are added even to basic packages that don't support chat, because the "Guard" order can come from pathing cubes in POIs, and those should be obeyed by every entity.

"Guard and return" dialog responses are also added to NPC dialogs, so users can command their NPCs to follow the same behavior. In this case the NPC will initially go to where the player is standing (and return there afterwards).